### PR TITLE
Unicode instead of html entity.

### DIFF
--- a/js/jquery.widowFix-1.3.2.js
+++ b/js/jquery.widowFix-1.3.2.js
@@ -114,7 +114,7 @@
 					}
 				}
 
-				var content = contentArray.join(' ') + '&nbsp;' + lastWord;
+				var content = contentArray.join(' ') + '\u0020' + lastWord;
 				$this.html(content);
 
 				if (wfOptions.linkFix) {


### PR DESCRIPTION
&nbsp; can break links that lie within the paragraph tag. Instead append a unicode character.
